### PR TITLE
Early escape hatch for broadcasters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# bundler state
+vendor/bundle/
+vendor/ruby/
+
 /.bundle/
 /.yardoc
 /_yardoc/

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,16 @@
+version: v1.0
+name: Ruby
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu2004
+blocks:
+  - name: bundle exec rspec
+    task:
+      jobs:
+        - name: bundle install
+          commands:
+            - checkout
+            - sem-version ruby 3.0.3
+            - bundle install --deployment --path vendor/bundle
+            - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-rvm:
-  - 2.2.3
-before_install: gem install bundler -v 1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,55 @@
+PATH
+  remote: .
+  specs:
+    wisper-activejob-broadcaster (0.2.1)
+      activejob
+      wisper
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activejob (7.0.1)
+      activesupport (= 7.0.1)
+      globalid (>= 0.3.6)
+    activesupport (7.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    concurrent-ruby (1.1.9)
+    diff-lcs (1.5.0)
+    globalid (1.0.0)
+      activesupport (>= 5.0)
+    i18n (1.8.11)
+      concurrent-ruby (~> 1.0)
+    minitest (5.15.0)
+    rake (13.0.6)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.3)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    wisper (2.0.1)
+
+PLATFORMS
+  x86_64-darwin-20
+  x86_64-linux
+
+DEPENDENCIES
+  bundler (~> 2.1)
+  rake (>= 12.3.3)
+  rspec
+  wisper-activejob-broadcaster!
+
+BUNDLED WITH
+   2.2.25

--- a/lib/wisper/activejob/broadcaster.rb
+++ b/lib/wisper/activejob/broadcaster.rb
@@ -5,7 +5,17 @@ module Wisper
   module Broadcasters
     class ActiveJobBroadcaster
       def broadcast(subscriber, _publisher, event, args)
-        subscriber.class.perform_later(event, args)
+        subscriber.class.perform_later(event, args) if perform?(subscriber, event, args)
+      end
+
+      private
+
+      def perform?(subscriber, event, args)
+        # If a predicate method of the format "event_name?" is defined on the subscriber, only run
+        # the subscriber if it evaluates to true
+        return subscriber.send("#{event}?", *args) if subscriber.respond_to?("#{event}?")
+
+        true
       end
     end
   end

--- a/lib/wisper/activejob/broadcaster/version.rb
+++ b/lib/wisper/activejob/broadcaster/version.rb
@@ -1,7 +1,7 @@
 module Wisper
   module Activejob
     module Broadcaster
-      VERSION = '0.1.1'.freeze
+      VERSION = '0.2.1'.freeze
     end
   end
 end

--- a/spec/wisper/activejob/broadcaster_spec.rb
+++ b/spec/wisper/activejob/broadcaster_spec.rb
@@ -1,11 +1,79 @@
 require 'spec_helper'
 
-describe Wisper::Activejob::Broadcaster do
+describe Wisper::Broadcasters::ActiveJobBroadcaster do
+  subject(:broadcast) { described_class.new.broadcast(subscriber, nil, :foo, []) }
+
+  let(:subscriber) { subscriber_class.new }
+  let(:subscriber_class) do
+    Class.new do
+      include Wisper::ActiveJob::Subscriber
+
+      def self.perform_later(_event, _args)
+        # no-op
+      end
+
+      def foo
+        # no-op
+      end
+    end
+  end
+
   it 'has a version number' do
     expect(Wisper::Activejob::Broadcaster::VERSION).not_to be nil
   end
 
-  it 'does something useful' do
-    expect(false).to eq(true)
+  it 'runs the job' do
+    expect(subscriber_class).to receive(:perform_later)
+    broadcast
+  end
+
+  context 'when defining a predicate' do
+    let(:subscriber_class) do
+      Class.new do
+        include Wisper::ActiveJob::Subscriber
+
+        def self.perform_later(_event, _args)
+          # no-op
+        end
+
+        def foo
+          # no-op
+        end
+
+        def foo?
+          true
+        end
+      end
+    end
+
+    it 'runs the job' do
+      expect(subscriber_class).to receive(:perform_later)
+      broadcast
+    end
+
+    context 'when the predicate returns false' do
+      let(:subscriber_class) do
+        Class.new do
+          include Wisper::ActiveJob::Subscriber
+
+          def self.perform_later(_event, _args)
+            # no-op
+          end
+
+          def foo
+            # no-op
+          end
+
+          def foo?
+            false
+          end
+        end
+      end
+
+      it 'skips the job' do
+        expect(subscriber_class).not_to receive(:perform_later)
+        broadcast
+      end
+    end
   end
 end


### PR DESCRIPTION
### Purpose

If we want to skip/no-op a subscriber method, we have to use guard clauses or other early escape mechanisms. This is fine for skipping behavior, but still imposes the overhead of creating, serializing, and executing jobs. If we adopt this PR (or similar functionality), we can avoid this unnecessary overhead.

### Summary

Adopt a simple pattern for dynamically specifying when listener jobs should run. If you choose to define a predicate method with a name that matches your listener method (EG - `foo?` for the `foo` listener method) that takes the same arguments, this predicate will be evaluated prior to running the perform method upon event broadcast, and the listener method will only run if it evaluates to true.

### Context

While scaling up the walkthrough build, a non-trivial amount of time was spent queueing and running no-op jobs (most notably the analytics listeners, many of which do nothing when the `DO_NOT_DELIVER` environment variable is set to false). In addition to wasting resources and time, it also made debugging and profiling performance more difficult because I'd see upwards of 500K-1M of these jobs in the Sidekiq low_priority queue.

### Guidance

Should we add some more tracking/logging around when these jobs are skipped? Are there better patterns we could adopt that result in less boilerplate or more clear intent around the predicate methods (EG - prefixing all of the predicates with `should_run_` or something?)

Given that this _should_ be purely opt-in functionality, risk seems acceptable, but this is definitely a fundamental and inherently high-risk bit of code. Any concerns here?

### Artifacts

[BUAPP-34772](https://betterup.atlassian.net/browse/BUAPP-34772)