### PR TITLE
Allow predicate methods to be private & protected

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    wisper-activejob-broadcaster (0.3.0)
+    wisper-activejob-broadcaster (0.3.1)
       activejob
       wisper
 
@@ -20,7 +20,7 @@ GEM
     diff-lcs (1.5.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    i18n (1.8.11)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     minitest (5.15.0)
     rake (13.0.6)
@@ -52,4 +52,4 @@ DEPENDENCIES
   wisper-activejob-broadcaster!
 
 BUNDLED WITH
-   2.2.25
+   2.2.32

--- a/lib/wisper/activejob/broadcaster.rb
+++ b/lib/wisper/activejob/broadcaster.rb
@@ -13,7 +13,7 @@ module Wisper
       def perform?(subscriber, event, args)
         # If a predicate method of the format "event_name?" is defined on the subscriber, only run
         # the subscriber if it evaluates to true
-        return subscriber.send("perform_#{event}?", *args) if subscriber.respond_to?("perform_#{event}?")
+        return subscriber.send("perform_#{event}?", *args) if subscriber.respond_to?("perform_#{event}?", true)
 
         true
       rescue StandardError

--- a/lib/wisper/activejob/broadcaster/version.rb
+++ b/lib/wisper/activejob/broadcaster/version.rb
@@ -1,7 +1,7 @@
 module Wisper
   module Activejob
     module Broadcaster
-      VERSION = '0.3.0'.freeze
+      VERSION = '0.3.1'.freeze
     end
   end
 end

--- a/spec/wisper/activejob/broadcaster_spec.rb
+++ b/spec/wisper/activejob/broadcaster_spec.rb
@@ -74,6 +74,33 @@ describe Wisper::Broadcasters::ActiveJobBroadcaster do
         expect(subscriber_class).not_to receive(:perform_later)
         broadcast
       end
+
+      context 'when the predicate is private' do
+        let(:subscriber_class) do
+          Class.new do
+            include Wisper::ActiveJob::Subscriber
+
+            def self.perform_later(_event, _args)
+              # no-op
+            end
+
+            def foo
+              # no-op
+            end
+
+            private
+
+            def perform_foo?
+              false
+            end
+          end
+        end
+
+        it 'skips the job' do
+          expect(subscriber_class).not_to receive(:perform_later)
+          broadcast
+        end
+      end
     end
 
     context 'when the predicate raises an error' do


### PR DESCRIPTION
While working with the new predicate based early escape functionality added in #3, I discovered predicate methods defined as private would not be considered.

This PR allows those predicate methods to be marked as private and still work.

Closes #6
